### PR TITLE
Update packages-lock.json

### DIFF
--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,13 +1,5 @@
 {
   "dependencies": {
-    "com.unity.ai.navigation": {
-      "version": "1.1.4",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.modules.ai": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
     "com.unity.2d.animation": {
       "version": "9.0.3",
       "depth": 1,
@@ -66,7 +58,7 @@
     },
     "com.unity.2d.sprite": {
       "version": "1.0.0",
-      "depth": 1,
+      "depth": 0,
       "source": "builtin",
       "dependencies": {}
     },
@@ -102,6 +94,15 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.ai.navigation": {
+      "version": "1.1.4",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.ai": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.burst": {
       "version": "1.8.8",
       "depth": 3,
@@ -110,12 +111,6 @@
         "com.unity.mathematics": "1.2.1"
       },
       "url": "https://packages.unity.com"
-    },
-    "com.unity.2d.sprite": {
-      "version": "1.0.0",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {}
     },
     "com.unity.collab-proxy": {
       "version": "2.0.7",


### PR DESCRIPTION
Fixed the issues with package-lock.json. Missing a curly bracket and contained a duplicate for the 2D sprite package. Likely caused by multiple people importing package on separate branches.